### PR TITLE
Minor fixes, deprecation support, and version updates

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -11,7 +11,7 @@
   <body>
 
     <div id="app-container"></div>
-    <script src="{%=o.htmlWebpackPlugin.assets.main%}"></script>
+    <script src="{%=o.htmlWebpackPlugin.files.chunks.main.entry%}"></script>
 
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -25,9 +25,6 @@
     "classnames": "^1.2.0",
     "react": "^0.13.0"
   },
-  "peerDependencies": {
-    "materialize-css": "^0.95.0"
-  },
   "devDependencies": {
     "autoprefixer-loader": "^1.2.0",
     "babel": "^5.1.11",
@@ -38,7 +35,7 @@
     "eslint-plugin-react": "^2.2.0",
     "file-loader": "^0.8.1",
     "html-webpack-plugin": "^1.3.0",
-    "materialize-css": "^0.95.3",
+    "materialize-css": "^0.96.1",
     "node-sass": "^2.1.1",
     "react-hot-loader": "^1.2.5",
     "react-router": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "^2.2.0",
     "file-loader": "^0.8.1",
     "html-webpack-plugin": "^1.3.0",
-    "materialize-css": "^0.96.1",
+    "materialize-css": "^0.97.0",
     "node-sass": "^2.1.1",
     "react-hot-loader": "^1.2.5",
     "react-router": "^0.13.2",

--- a/sass/components/_header.scss
+++ b/sass/components/_header.scss
@@ -1,5 +1,5 @@
 .top-nav {
-  @include box-shadow(none);
+  //@include box-shadow(none);
   align-items : center;
   display : flex;
   flex-wrap : nowrap;


### PR DESCRIPTION
In order to get webpack to run without error, I needed to make these minor changes 

1) support latest code deprecation warnings for webpack html injection
2) update dependency structure and version for materialize-css
3) comment out 1 sass line that calls for a missing mixins box-shadow

`energize` builds and runs without error for me now -- recommending code pull and testing by repository branch owner.
